### PR TITLE
fix: adjusting python code to fetch current metadata on personal cluster sandbox

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,7 +9,7 @@ config.load_incluster_config()
 v1 = client.CoreV1Api()
 
 
-role_label_key = "node-group"
+role_label_key = "eks.amazonaws.com/nodegroup"
 
 def label_node(node_name, key, value):
     body = {


### PR DESCRIPTION
Testing this using my sandbox, which doesnt have the lsdopen cluster nodes metadata